### PR TITLE
Signup/Login

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "client",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.6.0",

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -49,7 +49,7 @@ export default function Login(): JSX.Element {
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
             <Grid container>
               <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
+                <Typography className={classes.welcome} component="h1" variant="h3">
                   Welcome back!
                 </Typography>
               </Grid>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -52,7 +52,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <FormControl id="email" fullWidth={true} margin="dense">
             <FormLabel>
-              <Typography className={classes.label}>EMAIL ADDRESS</Typography>
+              <Typography className={classes.label}>email address</Typography>
             </FormLabel>
             <OutlinedInput
               className={classes.inputs}
@@ -68,7 +68,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
           </FormControl>
           <FormControl id="password" fullWidth={true} margin="dense">
             <FormLabel>
-              <Typography className={classes.label}>PASSWORD</Typography>
+              <Typography className={classes.label}>password</Typography>
             </FormLabel>
             <OutlinedInput
               className={classes.inputs}
@@ -80,7 +80,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
               placeholder="Your password"
               onChange={handleChange}
             />
-            <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
+            <FormHelperText>{touched.password ? errors.password : ''}</FormHelperText>
           </FormControl>
           <Box textAlign="center" marginTop={5}>
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -1,6 +1,10 @@
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
+import FormLabel from '@mui/material/FormLabel';
+import FormControl from '@mui/material/FormControl';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import FormHelperText from '@mui/material/FormHelperText';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Formik, FormikHelpers } from 'formik';
@@ -46,44 +50,38 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <TextField
-            id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="email"
-            autoComplete="email"
-            autoFocus
-            helperText={touched.email ? errors.email : ''}
-            error={touched.email && Boolean(errors.email)}
-            value={values.email}
-            onChange={handleChange}
-          />
-          <TextField
-            id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-              endAdornment: <Typography className={classes.forgot}>Forgot?</Typography>,
-            }}
-            type="password"
-            autoComplete="current-password"
-            helperText={touched.password ? errors.password : ''}
-            error={touched.password && Boolean(errors.password)}
-            value={values.password}
-            onChange={handleChange}
-          />
+          <FormControl id="email" fullWidth={true} margin="normal">
+            <FormLabel>
+              <Typography className={classes.label}>EMAIL ADDRESS</Typography>
+            </FormLabel>
+            <OutlinedInput
+              className={classes.inputs}
+              name="email"
+              autoComplete="email"
+              autoFocus={true}
+              error={touched.email && Boolean(errors.email)}
+              value={values.email}
+              placeholder="Your email"
+              onChange={handleChange}
+            />
+            <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
+          </FormControl>
+          <FormControl id="password" fullWidth={true} margin="normal">
+            <FormLabel>
+              <Typography className={classes.label}>PASSWORD</Typography>
+            </FormLabel>
+            <OutlinedInput
+              className={classes.inputs}
+              name="password"
+              autoComplete="current-password"
+              type="password"
+              error={touched.password && Boolean(errors.password)}
+              value={values.password}
+              placeholder="Your password"
+              onChange={handleChange}
+            />
+            <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
+          </FormControl>
           <Box textAlign="center" marginTop={5}>
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
               {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -50,7 +50,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <FormControl id="email" fullWidth={true} margin="normal">
+          <FormControl id="email" fullWidth={true} margin="dense">
             <FormLabel>
               <Typography className={classes.label}>EMAIL ADDRESS</Typography>
             </FormLabel>
@@ -66,7 +66,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
             />
             <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
           </FormControl>
-          <FormControl id="password" fullWidth={true} margin="normal">
+          <FormControl id="password" fullWidth={true} margin="dense">
             <FormLabel>
               <Typography className={classes.label}>PASSWORD</Typography>
             </FormLabel>

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -9,6 +9,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   label: {
     fontSize: 19,
     color: 'rgb(0,0,0,1)',
+    textTransform: 'uppercase',
   },
   inputs: {
     height: '3.5rem',

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -8,12 +8,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   label: {
     fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    color: 'rgb(0,0,0,1)',
   },
   inputs: {
-    marginTop: '.8rem',
-    height: '2rem',
+    height: '3.5rem',
     padding: '5px',
   },
   forgot: {
@@ -26,7 +24,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: 160,
     height: 56,
     borderRadius: theme.shape.borderRadius,
-    marginTop: 49,
     fontSize: 16,
     backgroundColor: '#3a8dff',
     fontWeight: 'bold',

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -13,9 +13,10 @@ const useStyles = makeStyles(() => ({
   },
   welcome: {
     fontSize: 26,
-    paddingBottom: 20,
+    paddingBottom: 50,
     color: '#000000',
     fontWeight: 700,
+    textAlign: 'center',
   },
 }));
 

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -50,8 +50,8 @@ export default function Register(): JSX.Element {
           <Box width="100%" maxWidth={450} p={3} alignSelf="center">
             <Grid container>
               <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
-                  Create an account
+                <Typography className={classes.welcome} component="h1" variant="h3">
+                  Sign Up
                 </Typography>
               </Grid>
             </Grid>

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -16,10 +16,10 @@ export default function Register(): JSX.Element {
   const { updateSnackBarMessage } = useSnackBar();
 
   const handleSubmit = (
-    { username, email, password }: { email: string; password: string; username: string },
-    { setSubmitting }: FormikHelpers<{ email: string; password: string; username: string }>,
+    { name, email, password }: { email: string; password: string; name: string },
+    { setSubmitting }: FormikHelpers<{ email: string; password: string; name: string }>,
   ) => {
-    register(username, email, password).then((data) => {
+    register(name, email, password).then((data) => {
       if (data.error) {
         console.error({ error: data.error.message });
         setSubmitting(false);

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -56,7 +56,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
           <FormControl id="email" fullWidth={true} margin="dense">
             <FormLabel>
-              <Typography className={classes.label}>EMAIL ADDRESS</Typography>
+              <Typography className={classes.label}>email address</Typography>
             </FormLabel>
             <OutlinedInput
               className={classes.inputs}
@@ -71,7 +71,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
           </FormControl>
           <FormControl id="name" fullWidth={true} margin="dense">
             <FormLabel>
-              <Typography className={classes.label}>NAME</Typography>
+              <Typography className={classes.label}>name</Typography>
             </FormLabel>
             <OutlinedInput
               className={classes.inputs}
@@ -87,12 +87,12 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
           </FormControl>
           <FormControl id="password" fullWidth={true} margin="dense">
             <FormLabel>
-              <Typography className={classes.label}>PASSWORD</Typography>
+              <Typography className={classes.label}>password</Typography>
             </FormLabel>
             <OutlinedInput
               className={classes.inputs}
               name="password"
-              autoComplete="current-password"
+              autoComplete="new-password"
               type="password"
               error={touched.password && Boolean(errors.password)}
               value={values.password}

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -1,6 +1,10 @@
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
+import FormLabel from '@mui/material/FormLabel';
+import FormControl from '@mui/material/FormControl';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import FormHelperText from '@mui/material/FormHelperText';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Formik, FormikHelpers } from 'formik';
@@ -51,65 +55,56 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <TextField
-            id="username"
-            label={<Typography className={classes.label}>Username</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="username"
-            autoComplete="username"
-            autoFocus
-            helperText={touched.username ? errors.username : ''}
-            error={touched.username && Boolean(errors.username)}
-            value={values.username}
-            onChange={handleChange}
-          />
-          <TextField
-            id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="email"
-            autoComplete="email"
-            helperText={touched.email ? errors.email : ''}
-            error={touched.email && Boolean(errors.email)}
-            value={values.email}
-            onChange={handleChange}
-          />
-          <TextField
-            id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            type="password"
-            autoComplete="current-password"
-            helperText={touched.password ? errors.password : ''}
-            error={touched.password && Boolean(errors.password)}
-            value={values.password}
-            onChange={handleChange}
-          />
+          <FormControl id="email" fullWidth={true} margin="none">
+            <FormLabel>
+              <Typography className={classes.label}>EMAIL ADDRESS</Typography>
+            </FormLabel>
+            <OutlinedInput
+              className={classes.inputs}
+              name="email"
+              autoComplete="email"
+              error={touched.email && Boolean(errors.email)}
+              value={values.email}
+              placeholder="Your email"
+              onChange={handleChange}
+            />
+            <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
+          </FormControl>
+          <FormControl id="username" fullWidth={true} margin="none">
+            <FormLabel>
+              <Typography className={classes.label}>USERNAME</Typography>
+            </FormLabel>
+            <OutlinedInput
+              className={classes.inputs}
+              name="username"
+              autoComplete="username"
+              autoFocus={true}
+              error={touched.username && Boolean(errors.username)}
+              value={values.username}
+              placeholder="Your username"
+              onChange={handleChange}
+            />
+            <FormHelperText>{touched.username ? errors.username : ''}</FormHelperText>
+          </FormControl>
+          <FormControl id="password" fullWidth={true} margin="none">
+            <FormLabel>
+              <Typography className={classes.label}>PASSWORD</Typography>
+            </FormLabel>
+            <OutlinedInput
+              className={classes.inputs}
+              name="password"
+              autoComplete="current-password"
+              error={touched.password && Boolean(errors.password)}
+              value={values.password}
+              placeholder="Create a password"
+              onChange={handleChange}
+            />
+            <FormHelperText>{touched.password ? errors.password : ''}</FormHelperText>
+          </FormControl>
 
           <Box textAlign="center" marginTop={5}>
             <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
+              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'SIGN UP'}
             </Button>
           </Box>
         </form>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -13,13 +13,13 @@ import useStyles from './useStyles';
 interface Props {
   handleSubmit: (
     {
-      username,
       email,
+      name,
       password,
     }: {
       email: string;
       password: string;
-      username: string;
+      name: string;
     },
     {
       setStatus,
@@ -27,7 +27,7 @@ interface Props {
     }: FormikHelpers<{
       email: string;
       password: string;
-      username: string;
+      name: string;
     }>,
   ) => void;
 }
@@ -40,10 +40,10 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
       initialValues={{
         email: '',
         password: '',
-        username: '',
+        name: '',
       }}
       validationSchema={Yup.object().shape({
-        username: Yup.string().required('Username is required').max(40, 'Username is too long'),
+        name: Yup.string().required('Name is required'),
         email: Yup.string().required('Email is required').email('Email is not valid'),
         password: Yup.string()
           .required('Password is required')
@@ -54,7 +54,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <FormControl id="email" fullWidth={true} margin="normal">
+          <FormControl id="email" fullWidth={true} margin="dense">
             <FormLabel>
               <Typography className={classes.label}>EMAIL ADDRESS</Typography>
             </FormLabel>
@@ -69,23 +69,23 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             />
             <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
           </FormControl>
-          <FormControl id="username" fullWidth={true} margin="normal">
+          <FormControl id="name" fullWidth={true} margin="dense">
             <FormLabel>
-              <Typography className={classes.label}>USERNAME</Typography>
+              <Typography className={classes.label}>NAME</Typography>
             </FormLabel>
             <OutlinedInput
               className={classes.inputs}
-              name="username"
-              autoComplete="username"
+              name="name"
+              autoComplete="name"
               autoFocus={true}
-              error={touched.username && Boolean(errors.username)}
-              value={values.username}
-              placeholder="Your username"
+              error={touched.name && Boolean(errors.name)}
+              value={values.name}
+              placeholder="Your name"
               onChange={handleChange}
             />
-            <FormHelperText>{touched.username ? errors.username : ''}</FormHelperText>
+            <FormHelperText>{touched.name ? errors.name : ''}</FormHelperText>
           </FormControl>
-          <FormControl id="password" fullWidth={true} margin="normal">
+          <FormControl id="password" fullWidth={true} margin="dense">
             <FormLabel>
               <Typography className={classes.label}>PASSWORD</Typography>
             </FormLabel>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -1,5 +1,4 @@
 import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import FormLabel from '@mui/material/FormLabel';
 import FormControl from '@mui/material/FormControl';
@@ -55,7 +54,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
         <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <FormControl id="email" fullWidth={true} margin="none">
+          <FormControl id="email" fullWidth={true} margin="normal">
             <FormLabel>
               <Typography className={classes.label}>EMAIL ADDRESS</Typography>
             </FormLabel>
@@ -70,7 +69,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             />
             <FormHelperText>{touched.email ? errors.email : ''}</FormHelperText>
           </FormControl>
-          <FormControl id="username" fullWidth={true} margin="none">
+          <FormControl id="username" fullWidth={true} margin="normal">
             <FormLabel>
               <Typography className={classes.label}>USERNAME</Typography>
             </FormLabel>
@@ -86,7 +85,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
             />
             <FormHelperText>{touched.username ? errors.username : ''}</FormHelperText>
           </FormControl>
-          <FormControl id="password" fullWidth={true} margin="none">
+          <FormControl id="password" fullWidth={true} margin="normal">
             <FormLabel>
               <Typography className={classes.label}>PASSWORD</Typography>
             </FormLabel>
@@ -94,6 +93,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
               className={classes.inputs}
               name="password"
               autoComplete="current-password"
+              type="password"
               error={touched.password && Boolean(errors.password)}
               value={values.password}
               placeholder="Create a password"

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -9,6 +9,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   label: {
     fontSize: 19,
     color: 'rgb(0,0,0,1)',
+    textTransform: 'uppercase',
   },
   inputs: {
     height: '3.5rem',

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -8,12 +8,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   label: {
     fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    color: 'rgb(0,0,0,1)',
   },
   inputs: {
-    marginTop: '1rem',
-    height: '2rem',
+    height: '3.5rem',
     padding: '5px',
   },
   forgot: {

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -17,9 +17,10 @@ const useStyles = makeStyles(() => ({
   },
   welcome: {
     fontSize: 26,
-    paddingBottom: 20,
+    paddingBottom: 50,
     color: '#000000',
     fontWeight: 700,
+    textAlign: 'center',
   },
 }));
 

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -2,15 +2,21 @@ import { createTheme } from '@mui/material/styles';
 
 export const theme = createTheme({
   typography: {
-    fontFamily: '"Open Sans", "sans-serif", "Roboto"',
+    fontFamily: '"Arial", "Roboto"',
     fontSize: 12,
     button: {
       textTransform: 'none',
       fontWeight: 700,
     },
+    h3: {
+      fontWeight: 'bold',
+    },
+    body1: {
+      fontWeight: 'bold',
+    },
   },
   palette: {
-    primary: { main: '#3A8DFF' },
+    primary: { main: '#f14140' },
   },
   shape: {
     borderRadius: 5,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3290,6 +3290,13 @@
   "resolved" "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   "version" "2.2.0"
 
+"bindings@^1.5.0":
+  "integrity" "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="
+  "resolved" "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  "version" "1.5.0"
+  dependencies:
+    "file-uri-to-path" "1.0.0"
+
 "bluebird@^3.5.5":
   "integrity" "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
   "resolved" "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
@@ -5921,6 +5928,19 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
+"fsevents@^1.2.7":
+  "integrity" "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
+  "version" "1.2.13"
+  dependencies:
+    "bindings" "^1.5.0"
+    "nan" "^2.12.1"
+
+"fsevents@^2.1.2", "fsevents@^2.1.3", "fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
+
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -8348,6 +8368,11 @@
   dependencies:
     "dns-packet" "^1.3.1"
     "thunky" "^1.0.2"
+
+"nan@^2.12.1":
+  "integrity" "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+  "resolved" "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz"
+  "version" "2.15.0"
 
 "nanoclone@^0.2.1":
   "integrity" "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="


### PR DESCRIPTION
### What this PR does (required):
- alter the colour of the SignUp/Login buttons as well as the text in theme and useStyles for login and signup to bring in line with mockup
- alter the style (bold, font) of the login/signup page and form to bring in line with mockup
- alter the parameter of onSubmit and Formik in SignUpForm and SignUp (username to name) to bring in line with mockup
- rebuild the textfield instead with components in order to use FormLabel instead of InputLabel to bring the look of SignUpForm and LoginForm in line with mockup

### Screenshots / Videos (front-end only):
![SignUp:Login frontend demo](https://user-images.githubusercontent.com/10319695/150608278-32fb3bab-8c14-4015-ac0e-676b9855e13c.png)

### Any information needed to test this feature (required):
- After merging in the request, the change should be visible right away. Just run the server and client like usual.

### Any issues with the current functionality (optional):